### PR TITLE
UCX Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@
 *~
 \#*#
 
+/deps
 /legion
+/ucx
+/ucc
+
 /build
 /build_*
 /install

--- a/experiment/common/setup.sh
+++ b/experiment/common/setup.sh
@@ -12,6 +12,56 @@ fi
 root_dir="$(dirname "$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")")"
 cd "$root_dir"
 
+DEP_CACHE="$PWD"/deps
+mkdir -p "$DEP_CACHE"
+
+# Borrow the Legion CI configuration here so that we're sure we're building the same way
+function build_ucx {
+    UCX_VERSION=1.20.1
+    UCX_SHA256=545c419a7b5e04643cb8bff5a19b3b5071a8f8f0605f1e8efb36f8f3d7bfb9d3
+
+    mkdir ucx
+    pushd ucx
+    if ! echo "$UCX_SHA256  $DEP_CACHE/ucx-$UCX_VERSION.tar.gz" | shasum -a 256 -c; then
+        curl -sL https://github.com/openucx/ucx/releases/download/v$UCX_VERSION/ucx-$UCX_VERSION.tar.gz -o "$DEP_CACHE"/ucx-$UCX_VERSION.tar.gz
+        echo "$UCX_SHA256  $DEP_CACHE/ucx-$UCX_VERSION.tar.gz" | shasum -a 256 -c
+    fi
+    tar --strip-components=1 -zxf "$DEP_CACHE"/ucx-$UCX_VERSION.tar.gz
+    if [[ -n $FUZZER_CUDA ]]; then
+        UCX_CONFIG_OPTS="--with-cuda=$FUZZER_CUDA"
+        # CI tests are run on a single node. So disable shared-memory and cuda ipc
+        # transports to be able to test some network functionality.
+        export UCX_TLS=^sm,cuda_ipc
+    else
+        UCX_CONFIG_OPTS="--without-cuda"
+        export UCX_TLS=^sm
+    fi
+    contrib/configure-release-mt --prefix="$PWD/install" $UCX_CONFIG_OPTS
+    make -j${FUZZER_THREADS:-4} install
+    popd
+}
+
+function build_ucc {
+    UCC_VERSION=1.7.0
+    UCC_SHA256=b40df0db75b8505844547574a3a7dad16c9033d7e1ca099ea8508bc57a62b454
+
+    mkdir ucc
+    pushd ucc
+    if ! echo "$UCC_SHA256  $DEP_CACHE/ucc-$UCC_VERSION.tar.gz" | shasum -a 256 -c; then
+        curl -sL https://github.com/openucx/ucc/archive/refs/tags/v$UCC_VERSION.tar.gz -o "$DEP_CACHE"/ucc-$UCC_VERSION.tar.gz
+        echo "$UCC_SHA256  $DEP_CACHE/ucc-$UCC_VERSION.tar.gz" | shasum -a 256 -c
+    fi
+    tar --strip-components=1 -zxf "$DEP_CACHE"/ucc-$UCC_VERSION.tar.gz
+
+    # Remove offload-arch=native.
+    sed -i 's/--offload-arch=native//g' ./cuda_lt.sh
+
+    ./autogen.sh
+    ./configure --prefix="$PWD/install" --with-ucx="$ucx_ROOT" --without-rocm
+    make -j${FUZZER_THREADS:-4} install
+    popd
+}
+
 function build_legion_config {
     config_name="$1"
     cmake_build_type="$2"
@@ -66,6 +116,18 @@ function build_fuzzer_config {
     popd
 }
 
+if echo $FUZZER_NETWORKS | grep -q -w ucx; then
+    if [[ ! -e ucx ]]; then
+        build_ucx
+    fi
+    export ucx_ROOT="$PWD/ucx/install"
+
+    if [[ ! -e ucc ]]; then
+        build_ucc
+    fi
+    export ucc_ROOT="$PWD/ucc/install"
+fi
+
 if [[ ! -e legion ]]; then
     clone_flags=()
     if [[ -n $branch ]]; then
@@ -78,12 +140,24 @@ pushd legion
 build_legion_config debug_single Debug
 build_legion_config spy_single Debug -DLegion_SPY=ON
 build_legion_config release_single Release
-build_legion_config debug_multi Debug "-DLegion_NETWORKS=gasnetex -DLegion_EMBED_GASNet=ON -DGASNet_CONDUIT=$FUZZER_CONDUIT -DLegion_EMBED_GASNet_CONFIGURE_ARGS=--disable-kind-cuda-uva"
-build_legion_config release_multi Release "-DLegion_NETWORKS=gasnetex -DLegion_EMBED_GASNet=ON -DGASNet_CONDUIT=$FUZZER_CONDUIT -DLegion_EMBED_GASNet_CONFIGURE_ARGS=--disable-kind-cuda-uva"
+if echo $FUZZER_NETWORKS | grep -q -w gasnetex; then
+    build_legion_config debug_multi_gex Debug "-DLegion_NETWORKS=gasnetex -DLegion_EMBED_GASNet=ON -DGASNet_CONDUIT=$FUZZER_GASNET_CONDUIT -DLegion_EMBED_GASNet_CONFIGURE_ARGS=--disable-kind-cuda-uva"
+    build_legion_config release_multi_gex Release "-DLegion_NETWORKS=gasnetex -DLegion_EMBED_GASNet=ON -DGASNet_CONDUIT=$FUZZER_GASNET_CONDUIT -DLegion_EMBED_GASNet_CONFIGURE_ARGS=--disable-kind-cuda-uva"
+fi
+if echo $FUZZER_NETWORKS | grep -q -w ucx; then
+    build_legion_config debug_multi_ucx Debug "-DLegion_NETWORKS=ucx -DCMAKE_INSTALL_RPATH=$ucx_ROOT/lib;$ucc_ROOT/lib"
+    build_legion_config release_multi_ucx Release "-DLegion_NETWORKS=ucx -DCMAKE_INSTALL_RPATH=$ucx_ROOT/lib;$ucc_ROOT/lib"
+fi
 popd
 
 build_fuzzer_config debug_single RelWithDebInfo
 build_fuzzer_config spy_single RelWithDebInfo
 build_fuzzer_config release_single Release
-build_fuzzer_config debug_multi RelWithDebInfo
-build_fuzzer_config release_multi Release
+if echo $FUZZER_NETWORKS | grep -q -w gasnetex; then
+    build_fuzzer_config debug_multi_gex RelWithDebInfo
+    build_fuzzer_config release_multi_gex Release
+fi
+if echo $FUZZER_NETWORKS | grep -q -w ucx; then
+    build_fuzzer_config debug_multi_ucx RelWithDebInfo
+    build_fuzzer_config release_multi_ucx Release
+fi

--- a/experiment/sapling/env.sh
+++ b/experiment/sapling/env.sh
@@ -1,5 +1,6 @@
 export FUZZER_MACHINE=sapling
 export FUZZER_THREADS=20
-export FUZZER_CONDUIT=ibv
+export FUZZER_NETWORKS="gasnetex ucx"
+export FUZZER_GASNET_CONDUIT=ibv
 
 export CC=gcc CXX=g++

--- a/experiment/sapling/run_all_tests.sh
+++ b/experiment/sapling/run_all_tests.sh
@@ -39,9 +39,13 @@ function run_fuzzer_config {
     FUZZER_EXE="$fuzzer_exe" FUZZER_MODE=$mode FUZZER_TEST_COUNT=$test_count FUZZER_SEED=$seed FUZZER_LAUNCHER="$launcher" FUZZER_EXTRA_FLAGS="$fuzzer_flags" sbatch --nodes 1 "experiment/$FUZZER_MACHINE/sbatch_fuzzer.sh"
 }
 
-run_fuzzer_config debug_single single
-run_fuzzer_config release_single single
-run_fuzzer_config debug_multi multi
-run_fuzzer_config release_multi multi
-run_fuzzer_config debug_multi multi "-fuzz:replicate 1"
-run_fuzzer_config release_multi multi "-fuzz:replicate 1"
+run_fuzzer_config      debug_single single
+run_fuzzer_config    release_single single
+run_fuzzer_config   debug_multi_gex  multi
+run_fuzzer_config release_multi_gex  multi
+run_fuzzer_config   debug_multi_gex  multi "-fuzz:replicate 1"
+run_fuzzer_config release_multi_gex  multi "-fuzz:replicate 1"
+run_fuzzer_config   debug_multi_ucx  multi
+run_fuzzer_config release_multi_ucx  multi
+run_fuzzer_config   debug_multi_ucx  multi "-fuzz:replicate 1"
+run_fuzzer_config release_multi_ucx  multi "-fuzz:replicate 1"


### PR DESCRIPTION
Adds a UCX build to experiments and machines can opt-in to GASNet or UCX by setting the `FUZZER_NETWORKS` variable in their `env.sh` file.

```bash
export FUZZER_NETWORKS="gasnetex ucx"
```

UCX build is configured to match Legion CI for consistency and currently has CUDA disabled.