### PR TITLE
Fuzz the fuzzer parameters in the runner harness

### DIFF
--- a/experiment/sapling/run_all_tests.sh
+++ b/experiment/sapling/run_all_tests.sh
@@ -28,7 +28,9 @@ function run_fuzzer_config {
         # We can't do as many tests in multi-node mode because SLURM has a
         # hard upper bound on the number of steps per job.
         test_count=20000
-        launcher="srun -n 2 --ntasks-per-node 2 --overlap"
+        launcher="srun -n {ranks} --ntasks-per-node {ranks} --overlap"
+        export FUZZER_THREADS=10
+        export FUZZER_MAX_RANKS=8
     else
         echo "Don't recognize fuzzer mode $mode"
         exit 1

--- a/experiment/sapling/run_all_tests.sh
+++ b/experiment/sapling/run_all_tests.sh
@@ -10,7 +10,7 @@ fi
 root_dir="$(dirname "$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")")"
 cd "$root_dir"
 
-export FUZZER_OP_COUNT=1000
+export FUZZER_OP_COUNT=256
 
 function run_fuzzer_config {
     config_name="$1"

--- a/experiment/sapling/sbatch_fuzzer.sh
+++ b/experiment/sapling/sbatch_fuzzer.sh
@@ -27,6 +27,7 @@ if [[ $FUZZER_MODE = single ]]; then
 elif [[ $FUZZER_MODE = multi ]]; then
     fuzzer_flags+=(
         --launcher="$FUZZER_LAUNCHER"
+        --max-ranks="$FUZZER_MAX_RANKS"
     )
 else
     echo "Don't recognize fuzzer mode $FUZZER_MODE"

--- a/experiment/sapling/sbatch_fuzzer.sh
+++ b/experiment/sapling/sbatch_fuzzer.sh
@@ -17,7 +17,7 @@ fuzzer_flags=(
     --fuzzer="$FUZZER_EXE"
     -j${FUZZER_THREADS:-4}
     -n${FUZZER_TEST_COUNT:-1000}
-    -o${FUZZER_OP_COUNT:-1000}
+    -o${FUZZER_OP_COUNT:-256}
     -s${FUZZER_SEED:-0}
     --extra="$FUZZER_EXTRA_FLAGS"
 )

--- a/runner.py
+++ b/runner.py
@@ -381,7 +381,7 @@ def driver():
     parser.add_argument(
         "--max-width",
         type=int,
-        default=256,
+        default=128,
         dest="max_width",
         help="maximum region tree width",
     )
@@ -395,7 +395,7 @@ def driver():
     parser.add_argument(
         "--max-fields",
         type=int,
-        default=32,
+        default=16,
         dest="max_fields",
         help="maximum region tree fields",
     )

--- a/runner.py
+++ b/runner.py
@@ -292,7 +292,7 @@ def run_tests(
 
         if launcher is not None and max_ranks is not None:
             ranks = generate_random(max_ranks)
-            test_launcher = launcher.replace("{ranks}", ranks)
+            test_launcher = launcher.replace("{ranks}", str(ranks))
         else:
             test_launcher = launcher
 

--- a/runner.py
+++ b/runner.py
@@ -16,7 +16,7 @@
 #
 
 from __future__ import annotations
-import argparse, dataclasses, glob, multiprocessing, os, queue, shlex, shutil, subprocess, sys, tempfile
+import argparse, dataclasses, glob, math, multiprocessing, os, queue, random, shlex, shutil, subprocess, sys, tempfile
 
 
 @dataclasses.dataclass
@@ -25,6 +25,10 @@ class FuzzArgs:
     tnum: int
     seed: int
     num_ops: int
+    width: int
+    branch: int
+    fields: int
+    size: int
     gpus_per_task: int
     gpus_per_node: int
     extra_args: list[str]
@@ -48,6 +52,21 @@ def pr(args, message):
 def cuda_visible_devices(args):
     first_gpu = (args.tid * args.gpus_per_task) % args.gpus_per_node
     return ",".join(map(str, range(first_gpu, first_gpu + args.gpus_per_task)))
+
+
+def generate_random(max_value):
+    # Generate random numbers from a reciprocal (log-uniform) distribution.
+    #
+    # The intuition is that we have a high-dimension space to fuzz, and most
+    # "interesting" points maximize a single dimension (but perhaps sometimes
+    # require multiple dimensions to be maximized). Because the cost of testing
+    # goes up with the number of increased dimensions, we want to minimize how
+    # many we increase at once while still ensuring we eventually cover the
+    # entire space.
+
+    assert max_value >= 1
+    max_exponent = math.log2(max_value)
+    return int(math.ceil(2 ** random.uniform(0.0, max_exponent)))
 
 
 def run_spy(args, logfiles):
@@ -83,7 +102,21 @@ def run_fuzzer(args):
                 ["/usr/bin/env", f"CUDA_VISIBLE_DEVICES={cuda_visible_devices(args)}"]
             )
     cmd.extend(
-        [args.fuzzer, "-fuzz:seed", str(args.seed), "-fuzz:ops", str(args.num_ops)]
+        [
+            args.fuzzer,
+            "-fuzz:seed",
+            str(args.seed),
+            "-fuzz:ops",
+            str(args.num_ops),
+            "-fuzz:width",
+            str(args.width),
+            "-fuzz:branch",
+            str(args.branch),
+            "-fuzz:fields",
+            str(args.fields),
+            "-fuzz:size",
+            str(args.size),
+        ]
     )
     if args.skip is not None:
         cmd.extend(["-fuzz:skip", str(args.skip)])
@@ -157,7 +190,7 @@ def bisect_start(args):
 
 def bisect_stop(args):
     if args.verbose >= 2:
-        pr(f"Bisecting {args.num_ops} ops at seed {args.seed}")
+        pr(args, f"Bisecting {args.num_ops} ops at seed {args.seed}")
     good = 0
     bad = args.num_ops
     last_failure = None
@@ -213,13 +246,18 @@ def report_failure(proc):
 def run_tests(
     thread_count,
     num_tests,
-    num_ops,
     base_seed,
+    max_ops,
+    max_width,
+    max_branch,
+    max_fields,
+    max_size,
     gpus_per_task,
     gpus_per_node,
     extra_args,
     fuzzer,
     launcher,
+    max_ranks,
     log,
     spy,
     verbose,
@@ -230,7 +268,12 @@ def run_tests(
         assert gpus_per_node > 0
         assert gpus_per_node % gpus_per_task == 0
 
+    if max_ranks is not None:
+        assert launcher is not None, "The flag --max-ranks requires --launcher"
+
     assert (log is None) or (spy is None), "Can only provide one of --log and --spy"
+
+    random.seed(base_seed)
 
     thread_pool = multiprocessing.Pool(thread_count)
 
@@ -240,6 +283,18 @@ def run_tests(
         num_queued += 1
 
         seed = base_seed + tid
+
+        num_ops = generate_random(max_ops)
+        width = generate_random(max_width)
+        branch = generate_random(max_branch)
+        fields = generate_random(max_fields)
+        size = generate_random(max_size)
+
+        if launcher is not None and max_ranks is not None:
+            ranks = generate_random(max_ranks)
+            test_launcher = launcher.replace("{ranks}", ranks)
+        else:
+            test_launcher = launcher
 
         def callback(r):
             result_queue.put(r)
@@ -256,11 +311,15 @@ def run_tests(
                     tnum=num_tests,
                     seed=seed,
                     num_ops=num_ops,
+                    width=width,
+                    branch=branch,
+                    fields=fields,
+                    size=size,
                     gpus_per_task=gpus_per_task,
                     gpus_per_node=gpus_per_node,
                     extra_args=extra_args,
                     fuzzer=fuzzer,
-                    launcher=launcher,
+                    launcher=test_launcher,
                     log=log,
                     spy=spy,
                     verbose=verbose,
@@ -309,15 +368,43 @@ def driver():
         help="number of tests to run per seed",
     )
     parser.add_argument(
-        "-o",
-        "--ops",
-        type=int,
-        default=100,
-        dest="num_ops",
-        help="number of operations to run per test",
+        "-s", "--seed", type=int, default=0, dest="base_seed", help="base seed to use"
     )
     parser.add_argument(
-        "-s", "--seed", type=int, default=0, dest="base_seed", help="base seed to use"
+        "-o",
+        "--max-ops",
+        type=int,
+        default=256,
+        dest="max_ops",
+        help="maximum operations to run per test",
+    )
+    parser.add_argument(
+        "--max-width",
+        type=int,
+        default=256,
+        dest="max_width",
+        help="maximum region tree width",
+    )
+    parser.add_argument(
+        "--max-branch",
+        type=int,
+        default=16,
+        dest="max_branch",
+        help="maximum region tree branch factor",
+    )
+    parser.add_argument(
+        "--max-fields",
+        type=int,
+        default=32,
+        dest="max_fields",
+        help="maximum region tree fields",
+    )
+    parser.add_argument(
+        "--max-size",
+        type=int,
+        default=16,
+        dest="max_size",
+        help="maximum region tree size per subregion",
     )
     parser.add_argument(
         "--gpus-per-task",
@@ -347,6 +434,13 @@ def driver():
         help="location of fuzzer executable",
     )
     parser.add_argument("--launcher", help="launcher command")
+    parser.add_argument(
+        "--max-ranks",
+        type=int,
+        required=False,
+        dest="max_ranks",
+        help="maximum ranks per test",
+    )
     parser.add_argument("--log", help="capture and save logs from failed runs")
     parser.add_argument("--spy", help="location of Legion Spy script")
     parser.add_argument(

--- a/src/mapper.cc
+++ b/src/mapper.cc
@@ -394,30 +394,6 @@ void FuzzMapper::random_mapping(const MapperContext ctx, RngChannel &rng,
   }
 
   {
-    std::vector<FieldID> fields;
-    if (rng.uniform_range(0, 1) == 0) {
-      FieldSpace handle = req.region.get_field_space();
-      runtime->get_field_space_fields(ctx, handle, fields);
-    } else {
-      fields.insert(fields.end(), req.instance_fields.begin(), req.instance_fields.end());
-    }
-    rng.shuffle(fields);
-    bool contiguous = rng.uniform_range(0, 1) == 0;
-    bool inorder = rng.uniform_range(0, 1) == 0;
-
-    {
-      auto msg = log_map.debug();
-      msg << "random_mapping: FieldConstraint fields";
-      for (FieldID field : fields) {
-        msg << " " << field;
-      }
-      msg << " contiguous " << contiguous << " inorder " << inorder;
-    }
-
-    constraints.add_constraint(FieldConstraint(fields, contiguous, inorder));
-  }
-
-  {
     IndexSpace is = req.region.get_index_space();
     Domain domain = runtime->get_index_space_domain(ctx, is);
     int dim = domain.get_dim();
@@ -441,6 +417,44 @@ void FuzzMapper::random_mapping(const MapperContext ctx, RngChannel &rng,
     constraints.add_constraint(OrderingConstraint(dimension_ordering, contiguous));
   }
 
+  // Create two sets of constraints:
+  //
+  //  1. A reduced set of constraints for instance search. This reduces the
+  //     combinatorial explosion due to field order in the constraint set that
+  //     reduces the number of potentially matching instances.
+  //
+  //  2. A full set of constraints for instance creation. We'll randomize
+  //     everything here to ensure we're hitting all the possible cases.
+
+  LayoutConstraintSet search_constraints = constraints;
+  search_constraints.add_constraint(
+      FieldConstraint(req.instance_fields, false /* contiguous */, false /* inorder */));
+
+  LayoutConstraintSet creation_constraints = constraints;
+  {
+    std::vector<FieldID> fields;
+    if (rng.uniform_range(0, 1) == 0) {
+      FieldSpace handle = req.region.get_field_space();
+      runtime->get_field_space_fields(ctx, handle, fields);
+    } else {
+      fields.insert(fields.end(), req.instance_fields.begin(), req.instance_fields.end());
+    }
+    rng.shuffle(fields);
+    bool contiguous = rng.uniform_range(0, 1) == 0;
+    bool inorder = rng.uniform_range(0, 1) == 0;
+
+    {
+      auto msg = log_map.debug();
+      msg << "random_mapping: FieldConstraint fields";
+      for (FieldID field : fields) {
+        msg << " " << field;
+      }
+      msg << " contiguous " << contiguous << " inorder " << inorder;
+    }
+
+    creation_constraints.add_constraint(FieldConstraint(fields, contiguous, inorder));
+  }
+
   // Coarsen the region by a random amount by walking up the region tree
   LogicalRegion region = req.region;
   while (runtime->has_parent_logical_partition(ctx, region) &&
@@ -451,28 +465,38 @@ void FuzzMapper::random_mapping(const MapperContext ctx, RngChannel &rng,
   log_map.debug() << "random_mapping: Region " << region;
   std::vector<LogicalRegion> regions = {region};
 
-  // Either force the runtime to create a fresh instance, or allow one to be
-  // reused. We want forced creation to be less likely because the constraints
-  // above already make a match unlikely
-  PhysicalInstance instance;
-  if (rng.uniform_range(0, 3) == 0) {
-    if (!runtime->create_physical_instance(ctx, memory, constraints, regions, instance,
-                                           true /* acquire */, LEGION_GC_MAX_PRIORITY)) {
-      log_map.fatal() << "random_mapping: Failed to create instance";
+  // Find an existing instance, and if that fails, create one.
+  std::vector<PhysicalInstance> found;
+  runtime->find_physical_instances(ctx, memory, search_constraints, regions, found,
+                                   true /* acquire */);
+
+  // Even if we found an instance, with some small probability create a new
+  // one anyway. To reduce memory usage we only want to do this infrequently.
+  bool force = rng.uniform_range(0, 15) == 0;
+  if (force || found.empty()) {
+    // We can't use LEGION_GC_MIN_PRIORITY here because any pinned instances
+    // will eventually cause OOM. Instead we just spread out the priorities as
+    // much as we can and try to exercise the Legion GC as much as possible.
+    GCPriority priority = LEGION_GC_MIN_PRIORITY + rng.uniform_range(1, 8192);
+
+    PhysicalInstance created;
+    if (runtime->create_physical_instance(ctx, memory, creation_constraints, regions,
+                                          created, true /* acquire */, priority)) {
+      log_map.debug() << "random_mapping: Created instance (forced: " << force << ")";
+      output.push_back(created);
+      return;
+    }
+
+    if (found.empty()) {
+      log_map.fatal() << "random_mapping: Failed to create instance, and no existing "
+                         "instances can be reused";
       abort();
     }
-    log_map.debug() << "random_mapping: Created instanced (forced)";
-  } else {
-    bool created;
-    if (!runtime->find_or_create_physical_instance(ctx, memory, constraints, regions,
-                                                   instance, created, true /* acquire */,
-                                                   LEGION_GC_NEVER_PRIORITY)) {
-      log_map.fatal() << "random_mapping: Failed to create instance";
-      abort();
-    }
-    log_map.debug() << "random_mapping: Created instance? " << created;
   }
-  output.push_back(instance);
+
+  log_map.debug() << "random_mapping: Reusing existing instances";
+  rng.shuffle(found);
+  output.insert(output.end(), found.begin(), found.end());
 }
 
 void FuzzMapper::random_sources(RngChannel &rng,

--- a/test.sh
+++ b/test.sh
@@ -30,9 +30,13 @@ if [[ $FUZZER_INSTALL_LEGION -eq 1 ]]; then
             -DCMAKE_CXX_FLAGS_DEBUG='-g -O2' # improve performance of debug code
             -DBUILD_SHARED_LIBS=ON # to improve link speed
         )
-        if [[ $FUZZER_DEBUG -eq 1 ]]; then
+        if [[ $FUZZER_SPY -eq 1 ]]; then
             legion_flags+=(
                 -DLegion_SPY=ON
+            )
+        fi
+        if [[ $FUZZER_VALGRIND -eq 1 ]]; then
+            legion_flags+=(
                 -DBUILD_MARCH= # to avoid -march=native for valgrind compatibility
             )
         fi


### PR DESCRIPTION
The fuzzer takes various parameters (op count, region tree width, branch factor, size, fields, etc.). Previously all our experiments hard-coded a set of parameters and users modified them by hand when they wanted to test a different configuration. This becomes clearly unscalable once you start doing more than a couple sets of runs and easily leads to failure if the human driver forgets any.

This also fixes the mapper because it turns out that when you run larger sizes we easily blow out the available memory by creating excessive numbers of instances.